### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 authors = ["Ed Sweeney <ed@onextent.com>"]
 description = "A cli tool for creating and updating actors from piped input"
 keywords = ["iot", "commandline", "actor", "digital", "twin"]
+repository = "https://github.com/navicore/navactor/"
 
 [[bin]]
 name = "nv"


### PR DESCRIPTION
Allow crates.io and others to link to repo